### PR TITLE
Fix dmaker.fan.p39: add sleep mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Credits: Thanks to [Rytilahti](https://github.com/rytilahti/python-miio) for all
 | Pedestal Fan Fan P15    | dmaker.fan.p15         | | |
 | Mi Smart Standing Fan 2 | dmaker.fan.p18         | BPLDS02DM  | AC, 15W, 30.2-55.8bB  |
 | Rosou SS4 Ventilator    | leshow.fan.ss4         | | |
+| Xiaomi Smart Tower Fan  | dmaker.fan.p39         | BPTS01DM | 22W, <=63dB |
 
 
 ## Features

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2256,6 +2256,7 @@ class XiaomiFanP39(XiaomiFanMiot):
 class OperationModeFanP39(Enum):
     Normal = 0
     Nature = 1
+    Sleep = 2
 
 
 class FanStatusP39(DeviceStatus):

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2317,7 +2317,7 @@ class FanP39(MiotDevice):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
-        model: str = MODEL_FAN_P33,
+        model: str = MODEL_FAN_P39,
     ) -> None:
         super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2306,7 +2306,6 @@ class FanP39(MiotDevice):
         "oscillate": {"siid": 2, "piid": 5},
         "angle": {"siid": 2, "piid": 6},
         "delay_off_countdown": {"siid": 2, "piid": 8},
-        "motor_control": {"siid": 2, "piid": 10},
         "speed": {"siid": 2, "piid": 11},
         "child_lock": {"siid": 3, "piid": 1},
     }

--- a/custom_components/xiaomi_miio_fan/manifest.json
+++ b/custom_components/xiaomi_miio_fan/manifest.json
@@ -12,5 +12,5 @@
     "construct==2.10.56",
     "python-miio>=0.5.12"
   ],
-  "version": "2023.6.0.0"
+  "version": "2023.7.0.0"
 }


### PR DESCRIPTION
The [spec](https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p39:1) specifies 3 modes are supported for this device, but only 2 are currently included. This breaks support if the fan is in sleep mode.

This PR adds the missing mode.